### PR TITLE
Reintegrate swift-sqlite with unicode as Swift Package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/readdle/swift-sqlite",
         "state": {
           "branch": null,
-          "revision": "f83bd1d0849d24e6bfc7373803395a6e19f1a5e2",
-          "version": "3.39.4"
+          "revision": "3793d5a70e18ba6ddbd3e28f154549d4e4c7befb",
+          "version": "3.39.4-unicode.1"
+        }
+      },
+      {
+        "package": "unicode",
+        "repositoryURL": "https://github.com/readdle/swift-unicode",
+        "state": {
+          "branch": null,
+          "revision": "fb8aac372834ccb8fab0a5c1742df862d47c4156",
+          "version": "68.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.4.4")),
-        .package(name: "SQLite", url: "https://github.com/readdle/swift-sqlite", .upToNextMinor(from: "3.39.4"))
+        .package(name: "SQLite", url: "https://github.com/readdle/swift-sqlite", .exact( "3.39.4-unicode.1"))
     ],
     targets: [
         .target(name: "SwiftFMDB",


### PR DESCRIPTION
Updated [swift-sqlite](https://github.com/readdle/swift-sqlite) version to [3.39.4-unicode.1](https://github.com/readdle/swift-sqlite/releases/tag/3.39.4-unicode.1), which depends to [unicode as Swift Package](https://github.com/readdle/swift-unicode).